### PR TITLE
Add simple MIPS payment module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 <p align="center">
   <img src="https://info.mollie.com/hubfs/github/odoo/logo.png" width="128" height="128"/>
 </p>
-<h1 align="center">Mollie addon for Odoo 16</h1>
+<h1 align="center">MIPS Payment for Odoo 18</h1>
 
 ## How to configure
 
-- Download the module and place the module in apps folder.
-- Install the python dependencies.
-- Install this module in your Odoo instance.
-- Open **Website > Configuration > Payment Acquirers** and open acquirers
-- Fill the API keys and credentials. (You will these keys from your mollie dashboard)
-- Click on Mollie Payment Methods tab and click on sync payment method button.
-- That's it you are ready to accept payments.
+- Download the module and place the module in your `addons` folder.
+- Install the python dependencies with `pip3 install -r requirements.txt`.
+- Install the **MIPS Payment Gateway** module from the apps menu.
+- Configure the credentials under **Website › Configuration › Payment Acquirers**.
+- After saving the credentials you are ready to accept payments through the MIPS iframe.
 
 ## Installing the Python packages
 You will need two Python packages for using this application.
@@ -20,4 +18,4 @@ You can install both these requirements by running the following command:
 pip3 install -r requirements.txt
 ```
 
-Learn more about it: https://apps.odoo.com/apps/modules/16.0/payment_mollie_official/
+Learn more about it: https://apps.odoo.com/apps/modules/18.0/payment_mollie_official/

--- a/payment_mips_simple/__init__.py
+++ b/payment_mips_simple/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/payment_mips_simple/__manifest__.py
+++ b/payment_mips_simple/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': 'MIPS Payment Gateway',
+    'version': '18.0.1.0.0',
+    'summary': 'Simple integration with MIPS payment iframe',
+    'author': 'Private',
+    'category': 'Payment',
+    'license': 'LGPL-3',
+    'depends': ['payment'],
+    'data': [
+        'data/mips_provider.xml',
+        'views/mips_templates.xml',
+    ],
+    'assets': {},
+    'installable': True,
+}

--- a/payment_mips_simple/data/mips_provider.xml
+++ b/payment_mips_simple/data/mips_provider.xml
@@ -1,0 +1,8 @@
+<odoo>
+    <record id="payment_provider_mips" model="payment.provider">
+        <field name="name">MIPS</field>
+        <field name="code">mips</field>
+        <field name="module_id" ref="base.module_payment"/>
+        <field name="state">test</field>
+    </record>
+</odoo>

--- a/payment_mips_simple/models/__init__.py
+++ b/payment_mips_simple/models/__init__.py
@@ -1,0 +1,2 @@
+from . import payment_provider
+from . import payment_transaction

--- a/payment_mips_simple/models/payment_provider.py
+++ b/payment_mips_simple/models/payment_provider.py
@@ -1,0 +1,17 @@
+from odoo import fields, models
+
+class PaymentProviderMips(models.Model):
+    _inherit = 'payment.provider'
+
+    code = fields.Selection(selection_add=[('mips', 'MIPS')])
+    mips_merchant_id = fields.Char('Merchant ID')
+    mips_form_id = fields.Char('Form ID')
+    mips_operator_id = fields.Char('Operator ID')
+    mips_operator_password = fields.Char('Operator Password')
+    mips_salt = fields.Char('IMN Salt')
+    mips_cipher_key = fields.Char('IMN Cipher Key')
+
+    def _get_supported_currency(self):
+        if self.code == 'mips':
+            return ['MUR', 'EUR', 'USD', 'GBP', 'ZAR']
+        return super()._get_supported_currency()

--- a/payment_mips_simple/models/payment_transaction.py
+++ b/payment_mips_simple/models/payment_transaction.py
@@ -1,0 +1,46 @@
+import json
+import requests
+
+from odoo import _, fields, models
+from odoo.exceptions import ValidationError
+
+class PaymentTransaction(models.Model):
+    _inherit = 'payment.transaction'
+
+    def _get_specific_rendering_values(self, processing_values):
+        if self.provider_code != 'mips':
+            return super()._get_specific_rendering_values(processing_values)
+
+        provider = self.provider_id
+        if not provider.mips_merchant_id:
+            raise ValidationError(_('MIPS credentials are not configured.'))
+
+        payload = {
+            'authentify': {
+                'id_merchant': provider.mips_merchant_id,
+                'id_form': provider.mips_form_id,
+                'id_operator': provider.mips_operator_id,
+                'operator_password': provider.mips_operator_password,
+            },
+            'order': {
+                'id_order': self.reference,
+                'amount': self.amount,
+                'currency': self.currency_id.name,
+            },
+            'request_mode': 'simple',
+            'touchpoint': 'web',
+            'iframe_behavior': {
+                'height': 508,
+                'width': 450,
+                'language': 'EN',
+            }
+        }
+        try:
+            response = requests.post('https://api.mips.mu/api/load_payment_zone',
+                                     json=payload,
+                                     timeout=60)
+            result = response.json()
+        except Exception as e:
+            raise ValidationError(_('MIPS: failed to create payment: %s') % e)
+        iframe_html = result.get('payment_iframe') or result.get('answer', {}).get('payment_zone_data')
+        return {'iframe_html': iframe_html}

--- a/payment_mips_simple/views/mips_templates.xml
+++ b/payment_mips_simple/views/mips_templates.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="payment_mips_form">
+        <t t-if="iframe_html">
+            <t t-raw="iframe_html"/>
+        </t>
+    </template>
+</odoo>


### PR DESCRIPTION
## Summary
- add a simple MIPS payment gateway module
- document how to configure MIPS payment
- update for Odoo 18 compatibility

## Testing
- `python -m py_compile payment_mips_simple/models/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684bd2cdc700832c825b56b2a5736d9a